### PR TITLE
Renames TrustFileSource to FileTrustSource

### DIFF
--- a/cmd/plugin/vault-auth-spire.go
+++ b/cmd/plugin/vault-auth-spire.go
@@ -107,7 +107,7 @@ func BackendFactory(ctx context.Context, backendConfig *logical.BackendConfig) (
 	spirePlugin.verifier = common.NewSvidVerifier()
 
 	if nil != settings.SourceOfTrust.File {
-		trustSource, err := common.NewTrustFileSource(settings.SourceOfTrust.File.Domains)
+		trustSource, err := common.NewFileTrustSource(settings.SourceOfTrust.File.Domains)
 		if err != nil {
 			return nil, errors.New("vault-auth-spire: Failed to initialize file TrustSource - " + err.Error())
 		}

--- a/internal/common/filetrustsource.go
+++ b/internal/common/filetrustsource.go
@@ -23,10 +23,10 @@ import (
 	"io/ioutil"
 )
 
-// FileTrustSource provides support for pem-file based trust sources. This trust source
-// should be provided a map of SPIFFE domains to pem files containing trust CAs. Each
+// FileTrustSource provides support for PEM-file based trust sources. This trust source
+// should be provided a map of SPIFFE domains to PEM files containing trust CAs. Each
 // domain can have 1 or more files assigned to it, and different domains can use the
-// same pem files. All certificates in the PEM file will be loaded.
+// same PEM files. All certificates in the PEM file will be loaded.
 type FileTrustSource struct {
 	domainPaths map[string][]string
 	domainCertificates map[string][]*x509.Certificate

--- a/internal/common/settings.go
+++ b/internal/common/settings.go
@@ -27,10 +27,10 @@ type Settings struct {
 }
 
 type SourceOfTrustSettings struct {
-	File *FileSourceOfTrustSettings
+	File *FileTrustSourceSettings
 }
 
-type FileSourceOfTrustSettings struct {
+type FileTrustSourceSettings struct {
 	Domains map[string][]string
 }
 
@@ -122,12 +122,12 @@ func readSourceOfTrustSettings() (*SourceOfTrustSettings, error) {
 	return sourceOfTrust, nil
 }
 
-func readFileSourceOfTrustSettings() (*FileSourceOfTrustSettings, error) {
+func readFileSourceOfTrustSettings() (*FileTrustSourceSettings, error) {
 	if !viper.IsSet("trustsource.file.domains") {
 		return nil, errors.New("trustsource.file.domains is required but not found")
 	}
 
-	fileSettings := new(FileSourceOfTrustSettings)
+	fileSettings := new(FileTrustSourceSettings)
 	fileSettings.Domains = viper.GetStringMapStringSlice("trustsource.file.domains")
 
 	return fileSettings, nil


### PR DESCRIPTION
Signed-off-by: Dennis Gove <dgove1@bloomberg.net>

**Describe your changes**
The name of file and struct for (old) `TrustFileSource` felt awkward so I've renamed it to `FileTrustSource`. I think this name is clearer.

I've also added comments in the file describing what a `FileTrustSource` is intended to do.

**Testing performed**
Manual testing to ensure the project builds, can be loaded and enabled as a plugin in vault, and properly verifies SVIDs using file trust sources.

**Additional context**
Long term when a SPIRE trust source is added the name and intention will be clearer if it is `SpireTrustSource`.
